### PR TITLE
updated Units.js

### DIFF
--- a/data/units.js
+++ b/data/units.js
@@ -34,7 +34,6 @@ var UNITS = {
     "<zepto>" :  [["z","Zepto","zepto"], 1e-21, "prefix"],
     "<yocto>" :  [["y","Yocto","yocto"], 1e-24, "prefix"],
 
-    "<1>"     :  [["1", "<1>"], 1, ""],
     /* length units */
     "<meter>" :  [["m","meter","meters","metre","metres"], 1.0, "length", ["<meter>"] ],
     "<inch>"  :  [["in","inch","inches","\""], 0.0254, "length", ["<meter>"]],

--- a/data/units.js
+++ b/data/units.js
@@ -34,7 +34,7 @@ var UNITS = {
     "<zepto>" :  [["z","Zepto","zepto"], 1e-21, "prefix"],
     "<yocto>" :  [["y","Yocto","yocto"], 1e-24, "prefix"],
 
-    "<1>"     :  [["1", "<1>"], 1, ""],
+    "<1>"     :  [["<1>"], 1, ""],
     /* length units */
     "<meter>" :  [["m","meter","meters","metre","metres"], 1.0, "length", ["<meter>"] ],
     "<inch>"  :  [["in","inch","inches","\""], 0.0254, "length", ["<meter>"]],


### PR DESCRIPTION
Removed "1" unit from "<1>". Values such as  45.11, 25.11, 911, etc does not read the values properly, but rather see 25.1 as the value